### PR TITLE
Introducing a basic Python pipeline based on setuptools

### DIFF
--- a/jobs/python.setup.py.yml
+++ b/jobs/python.setup.py.yml
@@ -1,0 +1,36 @@
+# Python setup.py
+# Job responsible for running Python steps for Linux and macOS
+
+jobs:
+- job: 'Linux'
+  strategy:
+    matrix:
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - script: |
+      sudo apt-get install --no-install-recommends -y \
+        git gcc musl-dev curl libldap2-dev libsasl2-dev openssh-client
+    displayName: 'Install system dependencies'
+  - template: ../steps/python.setup.py.yml
+
+
+- job: 'macOS'
+  strategy:
+    matrix:
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+  pool:
+    vmImage: 'macos-10.13'
+  steps:
+  - template: ../steps/python.setup.py.yml

--- a/steps/python.setup.py.yml
+++ b/steps/python.setup.py.yml
@@ -1,0 +1,56 @@
+# Python setup.py
+# Build, lint and test Python modules based on setuptools (setup.py)
+
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: $(python.version)
+    architecture: "x64"
+
+- script: |
+    pip install --upgrade setuptools==40.8.0 pip==19.0.3
+    pip install --no-cache-dir \
+      bumpversion==0.5.3 \
+      twine==1.12.1 \
+      Sphinx==1.8.3 \
+      sphinx-rtd-theme==0.4.2 \
+      recommonmark==0.5.0 \
+      sphinx-markdown-tables==0.0.9 \
+      pylint==2.3.1 \
+      setuptools-lint==0.6.0 \
+      pytest==4.3.0 \
+      pytest-runner==4.4 \
+      pytest-pylint==0.14.0 \
+      pytest-cov==2.6.1 \
+      coverage==4.5.2
+  displayName: "Install Python prerequisites"
+
+- script: python setup.py build
+  displayName: "Build"
+
+- script: |
+    python setup.py install --user
+    python setup.py lint --lint-output-format parseable
+  displayName: "Pylint"
+
+- script: |
+    python setup.py test --addopts '--cov-report xml:build/coverage.xml --cov-report html --cov-report html:build/htmlcov --cov-report term --cov-branch --junitxml=build/test_results.xml'
+  displayName: "Tests"
+
+- script: |
+    python setup.py install --user
+    python setup.py build_sphinx
+  displayName: "Docs"
+
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+      testResultsFiles: "**/test*.xml"
+      testRunTitle: "$(Agent.OS) - $(Build.BuildNumber)[$(Agent.JobName)]"
+
+- task: PublishCodeCoverageResults@1
+  inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'


### PR DESCRIPTION
This first version is using directly the underlying VM OS. I had some troubles to quickly get jobs in containers running as Azure expects certain tools installed in an image (https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops&tabs=yaml#requirements)