### PR TITLE
feat(release): do on-demand releases instead automatic ones

### DIFF
--- a/jobs/python.setup.py.yml
+++ b/jobs/python.setup.py.yml
@@ -2,8 +2,9 @@
 #
 # Job responsible for running Python steps for Linux and macOS. The jobs are responsible for
 #
-#  * building, linting and testing on Linux and macOS for various Python versions
-#  * publishing the Python package to PyPI
+#  * Building, linting and testing on Linux and macOS for various Python versions
+#  * Releasing on-demand the Python package to PyPI
+#    * This can be achieved by triggering a manual build and providing a queue variable 'release: true'
 #
 
 parameters:
@@ -46,14 +47,14 @@ jobs:
   - template: ../steps/python/python.build.yml
 
 
-- job: 'Publish'
+- job: 'Release'
   dependsOn:
     - macOS
     - Linux
-  condition: and(succeeded('macOS'), succeeded('Linux'), ne(variables['build.reason'], 'PullRequest'))
+  condition: and(succeeded('macOS'), succeeded('Linux'), ne(variables['build.reason'], 'PullRequest'), eq(variables['release'], 'true'))
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-  - template: ../steps/python/python.publish.yml
+  - template: ../steps/python/python.release.yml
     parameters:
       pypiConnector: "${{ parameters.pypiConnector }}"

--- a/steps/python/python.release.yml
+++ b/steps/python/python.release.yml
@@ -1,6 +1,6 @@
-# python.publish
+# python.release
 #
-# Publish Python package to PyPI.
+# Release Python package to PyPI.
 #
 
 parameters:


### PR DESCRIPTION
To avoid releasing for every single merge to master from now on releases can be triggered from
a build pipeline manually by providing the variable 'release: true'.