### PR TITLE
feat(dependencies): Use requirements_dev.txt file instead hardcoded dependencies

### DIFF
--- a/steps/python/python.build.yml
+++ b/steps/python/python.build.yml
@@ -11,21 +11,13 @@ steps:
 
 - template: python.deps.yml
 
-- script: |
-    pip install --no-cache-dir \
-      Sphinx==1.8.3 \
-      sphinx-rtd-theme==0.4.2 \
-      recommonmark==0.5.0 \
-      sphinx-markdown-tables==0.0.9 \
-      pylint==2.3.1 \
-      setuptools-lint==0.6.0 \
-      pytest==4.3.0 \
-      pytest-runner==4.4 \
-      pytest-pylint==0.14.0 \
-      pytest-cov==2.6.1 \
-      coverage==4.5.2
+- bash: |
+    if [ ! -f requirements_dev.txt ]; then
+      echo "ERROR: no requirements_dev.txt available in project!"
+      exit 1
+    fi
+    pip install --no-cache-dir -r requirements_dev.txt
   displayName: "Install build & test prerequisites"
-
 
 - script: python setup.py build
   displayName: "Build"

--- a/steps/python/python.deps.yml
+++ b/steps/python/python.deps.yml
@@ -5,5 +5,5 @@
 
 steps:
 - script: |
-    pip install --upgrade setuptools==40.8.0 pip==19.0.3
+    pip install --upgrade setuptools==40.8.0 pip==19.0.3 virtualenv==16.4.3
   displayName: "Install generic Python prerequisites"


### PR DESCRIPTION
This allows developers to define their own dependencies instead relying on hardcoded ones.
For backwards compatibility reasons the hardcoded lsit of dependencies is still defined. Once all pipelines use requirements
files we can remove that code.