### PR TITLE
Add Windows Builds to Python Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ This job is based on setuptools and runs builds, linter and tests using `python 
 
 #### python.build.yml
 
-#### python.deps.yml
-
 #### python.publish.yml
 
 ## Creating Azure Pipelines
@@ -32,7 +30,7 @@ The following steps will create a Python project generated with the [`tomtom-int
     cookiecutter gh:tomtom-international/cookiecutter-python
     ```
 
-1. Create a new repository on GitHub
+2. Create a new repository on GitHub
 ![Create repo](assets/create-gh-repo.png)
 
 1. Push the generated project to GitHub

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following steps will create a Python project generated with the [`tomtom-int
     cookiecutter gh:tomtom-international/cookiecutter-python
     ```
 
-2. Create a new repository on GitHub
+1. Create a new repository on GitHub
 ![Create repo](assets/create-gh-repo.png)
 
 1. Push the generated project to GitHub

--- a/jobs/python.setup.py.yml
+++ b/jobs/python.setup.py.yml
@@ -47,11 +47,27 @@ jobs:
   - template: ../steps/python/python.build.yml
 
 
+- job: 'Windows'
+  strategy:
+    matrix:
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+  pool:
+    vmImage: 'vs2017-win2016'
+  steps:
+  - template: ../steps/python/python.build.yml
+
+
 - job: 'Release'
   dependsOn:
     - macOS
     - Linux
-  condition: and(succeeded('macOS'), succeeded('Linux'), ne(variables['build.reason'], 'PullRequest'), eq(variables['release'], 'true'))
+    - Windows
+  condition: and(succeeded('macOS'), succeeded('Windows'), succeeded('Linux'), ne(variables['build.reason'], 'PullRequest'), eq(variables['release'], 'true'))
   pool:
     vmImage: 'ubuntu-16.04'
   steps:

--- a/steps/python/python.build.yml
+++ b/steps/python/python.build.yml
@@ -9,8 +9,6 @@ steps:
     versionSpec: $(python.version)
     architecture: "x64"
 
-- template: python.deps.yml
-
 - bash: |
     if [ ! -f requirements_dev.txt ]; then
       echo "ERROR: no requirements_dev.txt available in project!"

--- a/steps/python/python.build.yml
+++ b/steps/python/python.build.yml
@@ -26,7 +26,7 @@ steps:
   displayName: "Pylint"
 
 - script: |
-    python setup.py test --addopts '--cov-report xml:build/coverage.xml --cov-report html --cov-report html:build/htmlcov --cov-report term --cov-branch --junitxml=build/test_results.xml'
+    python setup.py test --addopts "--cov-report xml:build/coverage.xml --cov-report html --cov-report html:build/htmlcov --cov-report term --cov-branch --junitxml=build/test_results.xml"
   displayName: "Tests"
 
 - script: |

--- a/steps/python/python.build.yml
+++ b/steps/python/python.build.yml
@@ -14,7 +14,7 @@ steps:
       echo "ERROR: no requirements_dev.txt available in project!"
       exit 1
     fi
-    pip install --no-cache-dir -r requirements_dev.txt
+    pip install --user --no-cache-dir -r requirements_dev.txt
   displayName: "Install build & test prerequisites"
 
 - script: python setup.py build

--- a/steps/python/python.deps.yml
+++ b/steps/python/python.deps.yml
@@ -1,9 +1,0 @@
-# python.deps
-#
-# Installs Python prerequisites used by build and publish steps.
-#
-
-steps:
-- script: |
-    pip install --upgrade setuptools==40.8.0 pip==19.0.3 virtualenv==16.4.3
-  displayName: "Install generic Python prerequisites"

--- a/steps/python/python.release.yml
+++ b/steps/python/python.release.yml
@@ -28,8 +28,6 @@ steps:
     versionSpec: "3.6"
     architecture: "x64"
 
-- template: python.deps.yml
-
 - script: |
     pip install --no-cache-dir \
       bumpversion==0.5.3 \

--- a/steps/python/python.release.yml
+++ b/steps/python/python.release.yml
@@ -31,7 +31,9 @@ steps:
 - script: |
     pip install --no-cache-dir \
       bumpversion==0.5.3 \
-      twine==1.12.1
+      twine==1.12.1 \
+      setuptools==40.8.0 \
+      pip==19.0.3
   displayName: "Install publish prerequisites"
 
 - script: "bumpversion --message 'Bump version: {current_version} -> {new_version} ***NO_CI***' release"


### PR DESCRIPTION
* Adds Windows steps for Python 3.5, 3.6 and 3.7
* Remove the python.deps.yml step as these dependencies are handled when installing the package in question
* Use double quotes instead of single quotes for text execution command so it works in Windows