### PR TITLE
feat: use personal access token stored in Azure pipelines variable group (GitHub) when pushing to branch (eg. master)

### DIFF
--- a/jobs/python.setup.py.yml
+++ b/jobs/python.setup.py.yml
@@ -70,6 +70,8 @@ jobs:
   condition: and(succeeded('macOS'), succeeded('Windows'), succeeded('Linux'), ne(variables['build.reason'], 'PullRequest'), eq(variables['release'], 'true'))
   pool:
     vmImage: 'ubuntu-16.04'
+  variables:
+  - group: GitHub
   steps:
   - template: ../steps/python/python.release.yml
     parameters:

--- a/steps/python/python.release.yml
+++ b/steps/python/python.release.yml
@@ -54,5 +54,5 @@ steps:
 - script: "bumpversion --no-tag --message 'Bump version: {current_version} -> {new_version} ***NO_CI***' patch"
   displayName: "Bump version patch"
 
-- script: git push origin $(branch) --tags
+- script: git push --tags https://$(GH_TOKEN)@github.com/$(Build.Repository.Name).git $(branch)
   displayName: "Git push version patch"


### PR DESCRIPTION
This will fix the problem when triggering a job with `release: true` where the `git push master` failed due to insufficient permissions