### PR TITLE
WIP: feat(release): add versioning support #8

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,14 @@
+[bumpversion]
+current_version = 0.0.1-SNAPSHOT
+tag_name = {new_version}
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-zA-Z]+))?
+serialize =
+	{major}.{minor}.{patch}-{release}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = rel
+values =
+	SNAPSHOT
+	rel
+

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -5,10 +5,24 @@ trigger:
 
 jobs:
   - job: Release
-    condition: and(eq(variables['Build.Reason'], 'Manual'), eq(variables['release'], 'true')))
+    condition: or(eq(variables['release'], 'true'), ne(variables['Build.SourceBranchName'], 'master'))
     pool:
       vmImage: 'ubuntu-16.04'
     variables:
     - group: GitHub
     steps:
-    - bash: echo "Hello World"
+    - bash: |
+        # By default a release build on master won't do a dry-run except you explictly told so.
+        if [ "${{ variables['Build.SourceBranchName'] }}" == "master" ] && [ "$(dryRun)" != "true" ]; then
+           echo "##vso[task.setvariable variable=dryRun]false"
+        fi
+    - template: steps/git/prepare-push.yml
+      parameters:
+        gitCiUserMail: "$(GH_USER_MAIL)"
+        gitCiUserName: "$(GH_USER_NAME)"
+    - template: steps/release/bumpversion-release.yml
+    - template: steps/release/bumpversion-patch.yml
+    - template: steps/git/push-branch.yml
+      parameters:
+        branch: $(branch)
+        gitCiToken: "$(GH_TOKEN)"

--- a/steps/git/prepare-push.yml
+++ b/steps/git/prepare-push.yml
@@ -1,0 +1,23 @@
+parameters:
+  gitCiUserMail: ""
+  gitCiUserName: ""
+
+steps:
+- checkout: self
+  # Allow scripts to access the system token so that the pipeline can push git changes (eg. version bump)
+  persistCredentials: true
+
+- script: |
+    git config --global user.email "${{ parameters.gitCiUserMail }}"
+    git config --global user.name "${{ parameters.gitCiUserName }}"
+  displayName: "Configure git"
+
+# Checkout branch since by default Azure Pipelines do checkouts of specific commits (detached HEAD)
+# and we need to be at master to be able to push version bump changes.
+# We need to use a powershell script here to extract the proper branch name by removing 'refs/heads/' from the BUILD_SOURCEBRANCH variable
+# (eg. 'refs/heads/feature/feat-a' becomes 'feature/feat-a').
+- powershell: write-host "##vso[task.setvariable variable=branch]$($env:BUILD_SOURCEBRANCH.substring($env:BUILD_SOURCEBRANCH.indexOf('/', 5) + 1))"
+  displayName: "Extract the branch name"
+
+- script: git checkout $(branch)
+  displayName: "Checkout branch"

--- a/steps/git/prepare-push.yml
+++ b/steps/git/prepare-push.yml
@@ -10,14 +10,22 @@ steps:
 - script: |
     git config --global user.email "${{ parameters.gitCiUserMail }}"
     git config --global user.name "${{ parameters.gitCiUserName }}"
+    echo "source branch: $BUILD_SOURCEBRANCH"
   displayName: "Configure git"
 
 # Checkout branch since by default Azure Pipelines do checkouts of specific commits (detached HEAD)
 # and we need to be at master to be able to push version bump changes.
 # We need to use a powershell script here to extract the proper branch name by removing 'refs/heads/' from the BUILD_SOURCEBRANCH variable
 # (eg. 'refs/heads/feature/feat-a' becomes 'feature/feat-a').
-- powershell: write-host "##vso[task.setvariable variable=branch]$($env:BUILD_SOURCEBRANCH.substring($env:BUILD_SOURCEBRANCH.indexOf('/', 5) + 1))"
-  displayName: "Extract the branch name"
+#- powershell: write-host "##vso[task.setvariable variable=branch]$($env:BUILD_SOURCEBRANCH.substring($env:BUILD_SOURCEBRANCH.indexOf('/', 5) + 1))"
+#  displayName: "Extract the branch name"
+- bash: |
+    if [ "${{ variables['Build.Reason'] }}" != "PullRequest" ]; then
+      echo "##vso[task.setvariable variable=branch]$($env:BUILD_SOURCEBRANCH.substring($env:BUILD_SOURCEBRANCH.indexOf('/', 5) + 1))"
+    else
+      echo "##vso[task.setvariable variable=branch]$BUILD_SOURCEBRANCH"
+    fi
 
 - script: git checkout $(branch)
+  condition: ne(variables['Build.Reason'], 'PullRequest')
   displayName: "Checkout branch"

--- a/steps/git/push-branch.yml
+++ b/steps/git/push-branch.yml
@@ -1,0 +1,9 @@
+parameters:
+  gitCiToken: ""
+  branch: "master"
+
+steps:
+- script: |
+    if [ "$(dryRun)" != "false" ]; then arg="--dry-run"; fi;
+    git push  $arg --tags https://${{ parameters.gitCiToken }}@github.com/$(Build.Repository.Name).git ${{ parameters.branch }}
+  displayName: "Push changes"

--- a/steps/release/bumpversion-patch.yml
+++ b/steps/release/bumpversion-patch.yml
@@ -1,0 +1,10 @@
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: "3.6"
+    architecture: "x64"
+
+- script: |
+    if [ "$(dryRun)" != "false" ]; then arg="--dry-run"; fi;
+    bumpversion $arg --verbose --commit --no-tag --message 'Bump version: {current_version} -> {new_version} [skip ci]' patch
+  displayName: "Bump version patch"

--- a/steps/release/bumpversion-release.yml
+++ b/steps/release/bumpversion-release.yml
@@ -1,0 +1,14 @@
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: "3.6"
+    architecture: "x64"
+
+- script: |
+    pip install --no-cache-dir bumpversion==0.5.3
+  displayName: "Install bumpversion"
+
+- script: |
+    if [ "$(dryRun)" != "false" ]; then arg="--dry-run"; fi;
+    bumpversion $arg --verbose --commit --tag --message 'Bump version: {current_version} -> {new_version} [skip ci]' release
+  displayName: "Bump version release"


### PR DESCRIPTION
This  PR is about adding the capability to "release" the Azure templates so that users can pin to specific versions instead of relying on master.

Most of the changes here can and should be used as well in the python job/steps. Will address that in a separate PR in case we all decide that the approach is ok.