### PR TITLE
feat: Add condition to only execute pylint on Linux

### DIFF
--- a/steps/python/python.build.yml
+++ b/steps/python/python.build.yml
@@ -23,6 +23,7 @@ steps:
 - script: |
     python setup.py install --user
     python setup.py lint --lint-output-format parseable
+  condition: eq(variables['Agent.OS'], 'Linux')
   displayName: "Pylint"
 
 - script: |


### PR DESCRIPTION
Configure pipeline to only execute pylint on Linux. This has two benefits:
1. It should slightly speed up the total build time, as Windows and MacOS agents generally finish after Linux agents
2. It makes it simple to enable the spelling option in Pylint, since the Linux agent already has enchant installed - see https://github.com/tomtom-international/ebr-board/pull/8 for an example execution.