### PR TITLE
feat: Using Parameters to Define Build/Test Jobs Platforms and Python Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,41 @@ Azure DevOps service connector that defines the PyPI index (eg. pypi.org) where 
 
 *Default*: testpypi-tomtom-dev
 
-###### pythonUserVersion
+###### pythonDeployVersion
 
 The Python version used for creating the source distribution package deployed to the specified PyPI index.
 
 *Default*: 3.6
+
+###### pythonTestVersions
+
+Specify the Python versions to be used in all jobs *other* than deploy (which uses just pythonDeployVersion).
+
+*Default*:
+
+```yaml
+  - name: Python35
+    version: "3.5"
+  - name: Python36
+    version: "3.6"
+  - name: Python37
+    version: "3.7"
+```
+###### jobs
+
+Specify the job names and VM images. By default this runs on all three of the supported platforms, Linux, macOS and Windows.
+
+*Default*:
+
+```yaml
+  - name: Linux
+    vmImage: ubuntu-16.04
+  - name: macOS
+    vmImage: macos-10.13
+  - name: Windows
+    vmImage: vs2017-win2016
+```
+
 
 ## Creating Azure Pipelines
 

--- a/jobs/python.setup.py.yml
+++ b/jobs/python.setup.py.yml
@@ -8,9 +8,6 @@
 #
 
 parameters:
-  # This allows flexibility in the versions of Python tested, done as a workaround because Azure-DevOps variables are limited
-  # See https://stackoverflow.com/questions/54372758/azure-devops-yaml-pipelines-specification-of-matrix-through-build-variable
-  pythonTestVersions: "{Python35: {python.version: '3.5'}, Python36: {python.version: '3.6'}, Python37: {python.version: '3.7'}}"
   dockerDeploy: true
   dockerDeployFile: "Dockerfile"
   dockerRegistryConnector: "tomtom-docker-registry-bintray"
@@ -21,19 +18,15 @@ parameters:
   pythonUseVersion: "3.6"
 
 jobs:
-# Creates a output variable with the Python versions to test
-- job: 'Setup'
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - powershell: write-host "##vso[task.setvariable variable=jobMatrix;isOutput=true]$parameters.pythonTestVersions"
-    name: "Python_Versions"
-
 - job: 'Linux'
-  dependsOn:
-    - Setup
   strategy:
-    matrix: $[ dependencies.Setup.outputs['jobMatrix'] ]
+    matrix:
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
@@ -41,10 +34,14 @@ jobs:
 
 
 - job: 'macOS'
-  dependsOn:
-    - Setup
   strategy:
-    matrix: $[ dependencies.Setup.outputs['jobMatrix'] ]
+    matrix:
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
   pool:
     vmImage: 'macos-10.13'
   steps:
@@ -52,10 +49,14 @@ jobs:
 
 
 - job: 'Windows'
-  dependsOn:
-    - Setup
   strategy:
-    matrix: $[ dependencies.Setup.outputs['jobMatrix'] ]
+    matrix:
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
   pool:
     vmImage: 'vs2017-win2016'
   steps:

--- a/jobs/python.setup.py.yml
+++ b/jobs/python.setup.py.yml
@@ -8,6 +8,9 @@
 #
 
 parameters:
+  # This allows flexibility in the versions of Python tested, done as a workaround because Azure-DevOps variables are limited
+  # See https://stackoverflow.com/questions/54372758/azure-devops-yaml-pipelines-specification-of-matrix-through-build-variable
+  pythonTestVersions: "{Python35: {python.version: '3.5'}, Python36: {python.version: '3.6'}, Python37: {python.version: '3.7'}}"
   dockerDeploy: true
   dockerDeployFile: "Dockerfile"
   dockerRegistryConnector: "tomtom-docker-registry-bintray"
@@ -18,15 +21,19 @@ parameters:
   pythonUseVersion: "3.6"
 
 jobs:
+# Creates a output variable with the Python versions to test
+- job: 'Setup'
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - powershell: write-host "##vso[task.setvariable variable=jobMatrix;isOutput=true]$parameters.pythonTestVersions"
+    name: "Python_Versions"
+
 - job: 'Linux'
+  dependsOn:
+    - Setup
   strategy:
-    matrix:
-      Python35:
-        python.version: '3.5'
-      Python36:
-        python.version: '3.6'
-      Python37:
-        python.version: '3.7'
+    matrix: $[ dependencies.Setup.outputs['jobMatrix'] ]
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
@@ -34,14 +41,10 @@ jobs:
 
 
 - job: 'macOS'
+  dependsOn:
+    - Setup
   strategy:
-    matrix:
-      Python35:
-        python.version: '3.5'
-      Python36:
-        python.version: '3.6'
-      Python37:
-        python.version: '3.7'
+    matrix: $[ dependencies.Setup.outputs['jobMatrix'] ]
   pool:
     vmImage: 'macos-10.13'
   steps:
@@ -49,14 +52,10 @@ jobs:
 
 
 - job: 'Windows'
+  dependsOn:
+    - Setup
   strategy:
-    matrix:
-      Python35:
-        python.version: '3.5'
-      Python36:
-        python.version: '3.6'
-      Python37:
-        python.version: '3.7'
+    matrix: $[ dependencies.Setup.outputs['jobMatrix'] ]
   pool:
     vmImage: 'vs2017-win2016'
   steps:

--- a/jobs/python.setup.py.yml
+++ b/jobs/python.setup.py.yml
@@ -20,52 +20,29 @@ parameters:
   - name: Python35
     version: "3.5"
   - name: Python36
-    version: "36"
+    version: "3.6"
   - name: Python37
     version: "3.7"
+  testJobs:
+  - name: Linux
+    vmImage: ubuntu-16.04
+  - name: macOS
+    vmImage: macos-10.13
+  - name: Windows
+    vmImage: vs2017-win2016
 
 jobs:
-- job: 'Linux'
-  strategy:
-    matrix: 
-      ${{ each pyVersion in parameters.pythonTestVersions }}:
-        ${{ pyVersion.name }}:
-          python.version: ${{ pyVersion.version }}
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - template: ../steps/python/python.build.yml
-
-
-- job: 'macOS'
-  strategy:
-    matrix:
-      Python35:
-        python.version: '3.5'
-      Python36:
-        python.version: '3.6'
-      Python37:
-        python.version: '3.7'
-  pool:
-    vmImage: 'macos-10.13'
-  steps:
-  - template: ../steps/python/python.build.yml
-
-
-- job: 'Windows'
-  strategy:
-    matrix:
-      Python35:
-        python.version: '3.5'
-      Python36:
-        python.version: '3.6'
-      Python37:
-        python.version: '3.7'
-  pool:
-    vmImage: 'vs2017-win2016'
-  steps:
-  - template: ../steps/python/python.build.yml
-
+- ${{ each job in parameters.testJobs }}:
+  - job: ${{ job.name }}
+    strategy:
+      matrix: 
+        ${{ each pyVersion in parameters.pythonTestVersions }}:
+          ${{ pyVersion.name }}:
+            python.version: ${{ pyVersion.version }}
+    pool:
+      vmImage: ${{ job.vmImage }}
+    steps:
+    - template: ../steps/python/python.build.yml
 
 - job: 'Deploy'
   dependsOn:

--- a/jobs/python.setup.py.yml
+++ b/jobs/python.setup.py.yml
@@ -23,7 +23,7 @@ parameters:
     version: "3.6"
   - name: Python37
     version: "3.7"
-  testJobs:
+  jobs:
   - name: Linux
     vmImage: ubuntu-16.04
   - name: macOS
@@ -32,7 +32,7 @@ parameters:
     vmImage: vs2017-win2016
 
 jobs:
-- ${{ each job in parameters.testJobs }}:
+- ${{ each job in parameters.jobs }}:
   - job: ${{ job.name }}
     strategy:
       matrix: 

--- a/jobs/python.setup.py.yml
+++ b/jobs/python.setup.py.yml
@@ -15,18 +15,22 @@ parameters:
   # Name of 'Service connection' defined in Azure DevOps project settings
   # See https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/twine-authenticate?view=azure-devops#arguments
   pypiConnector: "testpypi-tomtom-dev"
-  pythonUseVersion: "3.6"
+  pythonDeployVersion: "3.6"
+  pythonTestVersions:
+  - name: Python35
+    version: "3.5"
+  - name: Python36
+    version: "36"
+  - name: Python37
+    version: "3.7"
 
 jobs:
 - job: 'Linux'
   strategy:
-    matrix:
-      Python35:
-        python.version: '3.5'
-      Python36:
-        python.version: '3.6'
-      Python37:
-        python.version: '3.7'
+    matrix: 
+      ${{ each pyVersion in parameters.pythonTestVersions }}:
+        ${{ pyVersion.name }}:
+          python.version: ${{ pyVersion.version }}
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
@@ -90,4 +94,4 @@ jobs:
       gitCiUserMail: "$(GH_USER_MAIL)"
       gitCiUserName: "$(GH_USER_NAME)"
       pypiConnector: "${{ parameters.pypiConnector }}"
-      pythonUseVersion: "${{ parameters.pythonUseVersion }}"
+      pythonUseVersion: "${{ parameters.pythonDeployVersion }}"


### PR DESCRIPTION
Allows configuring what platforms and Python versions the building and testing set of jobs take place on. By default it remains Python 3.5 - 3.7, and Ubuntu, MacOS and Windows.

This enables disabling builds for unsupported platforms/Python versions, as was needed in https://github.com/tomtom-international/ebr-trackerbot/pull/4 since it cannot support Python 3.5.